### PR TITLE
Changed scrolltop to left on get started page

### DIFF
--- a/src/components/ScrollTop/Scrolltop.js
+++ b/src/components/ScrollTop/Scrolltop.js
@@ -27,8 +27,30 @@ const useStyles = makeStyles((theme) => ({
       right: "2.5%",
     },
   },
+  toLeft: {
+    zIndex: 5,
+    position: "fixed",
+    bottom: "5vh",
+    backgroundColor: "#DCDCDC",
+    color: "black",
+    "&:hover, &.Mui-focusVisible": {
+      transition: "0.3s",
+      color: "#f24638",
+      backgroundColor: "#DCDCDC",
+    },
+    [theme.breakpoints.up("xs")]: {
+      left: "8%",
+      backgroundColor: "#f24638",
+    },
+    [theme.breakpoints.up("sm")]: {
+      left: "4%",
+    },
+    [theme.breakpoints.up("lg")]: {
+      left: "2.5%",
+    },
+  }
 }));
-const Scrolltop = ({ showBelow }) => {
+const Scrolltop = ({ showBelow,showLeft }) => {
   const classes = useStyles();
 
   const [show, setShow] = useState(showBelow ? false : true);
@@ -57,7 +79,8 @@ const Scrolltop = ({ showBelow }) => {
       {show && (
         <IconButton
           onClick={handleClick}
-          className={classes.toTop}
+          className={showLeft ? `${classes.toLeft}` : `${classes.toTop}`}
+          
           aria-label="to top"
           component="span"
         >

--- a/src/pages/Section/Section.js
+++ b/src/pages/Section/Section.js
@@ -1,5 +1,6 @@
 import React,{useState,useEffect} from "react";
 import { Link } from "react-router-dom";
+import Scrolltop from "../../components/ScrollTop/Scrolltop";
 import Sectionscard from "../../components/UI/Sectionscard/SectionCard";
 import Chatbot from '../../components/UI/Chatbot/Chatbot'
 import ImgSrc from "../../shared/ImgSrc";
@@ -104,7 +105,7 @@ useEffect(() => {
       ):(
         <div id="chatbot"><Chatbot/></div>
       )}
-      
+      <Scrolltop showBelow={250} showLeft={true}/>
       <Footer />
     </div>
   );


### PR DESCRIPTION
### Fixes #204 

- scrolltop button will be on left on get started page and on right on other pages.